### PR TITLE
グループ作成機能実装

### DIFF
--- a/app/assets/stylesheets/group.scss
+++ b/app/assets/stylesheets/group.scss
@@ -11,6 +11,7 @@
     letter-spacing: 2px;
     font-size: 24px;
     text-align: center;
+    font-weight: bold;
   }
 
   &__errors {
@@ -40,6 +41,7 @@
   }
 
   &__field {
+    @include clearfix;
     margin-top: 30px;
 
     &--left {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,8 @@ class GroupsController < ApplicationController
     if @group.save
       redirect_to root_path, notice: 'グループが作成されました'
     else
-      redirect_to new_group_path, alert: 'グループ名を入力してください'
+      flash.now[:alert] = 'グループが作成されませんでした'
+      render action: :new
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,12 +1,28 @@
 class GroupsController < ApplicationController
 
+  def new
+    @group = Group.new
+  end
+
   def index
+  end
+
+  def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループが作成されました'
+    else
+      redirect_to new_group_path, alert: 'グループ名を入力してください'
+    end
   end
 
   def edit
   end
 
-  def new
+  private
+  def group_params
+    params.require(:group).permit(:name)
   end
+
 
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,23 +1,27 @@
-%form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    %input{:name => "utf8", :type => "hidden", :value => "✓"}/
-    %input{:name => "_method", :type => "hidden", :value => "patch"}/
-    %input{:name => "authenticity_token", :type => "hidden", :value => "U5ABp0/UobRQTSwsR0V40bX1w3t0rZ0CTqrVyLecD+L6sdhBRO/gVcKy7w/Rgxnc7Hf0Ts39996dal3to5fTag=="}/
+.chat-group-form
+  %h1 新規チャットグループ
+  = form_for(@group) do |f|
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+        = f.label :name,"グループ名",class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text", :value => "ほげー"}/
+        = f.text_field :name,placeholder: "グループ名を入力して下さい", class: 'chat-group-form__input'
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+        = f.label :name,"チャットメンバーを追加", class: "chat-group-form__label"
       .chat-group-form__field--right
         .chat-group-form__search.clearfix
-          %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+          //ユーザー検索機能は編集機能で実装予定
         #user-search-result
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+        = f.label :name,"チャットメンバー", class: "chat-group-form__label"
+      .chat-group-form__field--right
+        #chat-group-users
+          #chat-group-user-22.chat-group-user.clearfix
+            /編集機能で実装予定
+            %p.chat-group-user__name seo_kyohei
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        = f.submit "Save", class: "chat-group-form__action-btn", desable_with: "save"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -8,7 +8,7 @@
         USER
       = link_to edit_user_registration_path do
         = fa_icon 'cog 2x'
-      = link_to "/chatspace" do
+      = link_to new_group_path do
         = fa_icon 'pencil-square-o 2x'
     .group-info
       .group-info__name

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,1 @@
-.chat-group-form
-  %h1 新規チャットグループ
-  = render partical: "form"
+= render partial: "form"


### PR DESCRIPTION
# WHAT
* SCSSファイルに追記
* 提供されたグループ作成情報の送信機能をform_forを使った記述に変更
* groupsコントローラーに追記、renderを用いた記述に修正。
* 最初のビューから新規グループ作成画面に遷移するためのリンクを設定

# WHY
* ビューの見た目を修正
* グループ情報をデータベースに保存できるようにするため