### PR TITLE
グループ作成機能にメンバー追加機能を実装する

### DIFF
--- a/app/assets/stylesheets/group.scss
+++ b/app/assets/stylesheets/group.scss
@@ -106,3 +106,19 @@
     border: 0;
   }
 }
+
+.chat-group-form__search{
+  @include clearfix;
+  #user-search-hidden{
+    display: none;
+  }
+}
+
+#user-search-result{
+  .list{
+    list-style-type: none;
+    line-height: 50px;
+    padding-left: 15px;
+    border-bottom: 1px solid #ddd;
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,7 @@ class GroupsController < ApplicationController
 
   def new
     @group = Group.new
+    @users = User.all
   end
 
   def index
@@ -33,7 +34,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name, { :user_ids => [] })
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,4 +2,5 @@ class Group < ApplicationRecord
   validates_presence_of :name
   has_many :users, through: :group_users
   has_many :group_users
+  accepts_nested_attributes_for :group_users
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -8,7 +8,10 @@
     .chat-group-form__field--left
       = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label"
     .chat-group-form__field--right
-      .chat-group-form__search.clearfix
+      .chat-group-form__search
+        = f.label :users, style: "visibility:hidden"
+        = collection_check_boxes(:group, :user_ids, @users, :id, :name) do |u|
+          = u.label { u.check_box + u.text }
       #user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left


### PR DESCRIPTION
# WHAT
* ユーザー追加フォーム関連のスタイルを指定
* groupsコントローラのストロングパラメータ内容変更、newアクションに追記
* groupモデルに追記
* ビューファイルにチェックボックス実装

# WHY
* グループ新規作成の際にユーザーを任意で追加できるようにするため
* ユーザー追加の際に、すべてのユーザーの情報を取得するため
* 追加したいユーザーをチェックボックスで選択するため
* グループ作成の際、グループに所属するユーザーの情報を中間テーブルに保存するため

ブラウザ上でのグループ作成時、中間テーブルに選択したメンバーの情報が保存されていることを確認しました。レビューよろしくおねがいします。

